### PR TITLE
Style Modification (using AC-Twoline Tampermonkey script)

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -10,12 +10,21 @@ async function run(question) {
   container.className = "chat-gpt-container";
   container.innerHTML = '<p class="loading">Waiting for ChatGPT response...</p>';
 
-  const siderbarContainer = document.getElementById("rhs");
-  if (siderbarContainer) {
-    siderbarContainer.prepend(container);
+  // if using AC-Twoline Tampermonkey script
+  const acTwoline = document.querySelector("#sp-ac-container")
+  if (acTwoline) {  
+    const mainContainer = document.querySelector("#search")
+    if (mainContainer) {
+      mainContainer.prepend(container);
+    }
   } else {
-    container.classList.add("sidebar-free");
-    document.getElementById("rcnt").appendChild(container);
+    const siderbarContainer = document.getElementById("rhs");
+    if (siderbarContainer) {
+      siderbarContainer.prepend(container);
+    } else {
+      container.classList.add("sidebar-free");
+      document.getElementById("rcnt").appendChild(container);
+    }
   }
 
   const port = chrome.runtime.connect();


### PR DESCRIPTION
Modify the style

Because the [AC-Twoline Tampermonkey script](https://greasyfork.org/zh-CN/scripts/14178-ac-baidu-%E9%87%8D%E5%AE%9A%E5%90%91%E4%BC%98%E5%8C%96%E7%99%BE%E5%BA%A6%E6%90%9C%E7%8B%97%E8%B0%B7%E6%AD%8C%E5%BF%85%E5%BA%94%E6%90%9C%E7%B4%A2-favicon-%E5%8F%8C%E5%88%97) is used, move from the sidebar to the center.

Example: 

![image](https://user-images.githubusercontent.com/42215787/205509801-e6d85fef-5622-4063-951f-320cf7e98f61.png)
