### PR TITLE
Add firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A Chrome extension to show ChatGPT response in Google search results
 4. Enable Developer Mode.
 5. Drag the unzipped folder anywhere on the page to import it (do not delete the folder afterwards).
 
+### Firefox Installation
+
+1. Clone the repo
+2. Install dependencies with `npm`
+3. Run `./build.sh firefox`
+4. Go to `about:debugging` and load temporary add-on by selecting any file in the `build` directory
+
 ### Chrome Web Store
 
 Still waiting for review
@@ -24,13 +31,6 @@ Still waiting for review
 2. Install dependencies with `npm`
 3. Run `./build.sh`
 4. Load the `build` directory to Chrome
-
-## Build from source for Firefox
-
-1. Clone the repo
-2. Install dependencies with `npm`
-3. Run `./build.sh firefox`
-4. Go to `about:debugging` and load temporary add-on by selecting any file in the `build` directory
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Still waiting for review
 3. Run `./build.sh`
 4. Load the `build` directory to Chrome
 
+## Build from source for Firefox
+
+1. Clone the repo
+2. Install dependencies with `npm`
+3. Run `./build.sh firefox`
+4. Go to `about:debugging` and load temporary add-on by selecting any file in the `build` directory
+
 ## Credit
 
 This project is inspired by [ZohaibAhmed/ChatGPT-Google](https://github.com/ZohaibAhmed/ChatGPT-Google)

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,12 @@
 rm -rf build
 npx esbuild src/content-script/index.mjs src/background/index.mjs --bundle --outdir=build
 cp src/*.css build/
-cp src/*.json build/
+case $1 in
+  firefox)
+    cp src/manifest.v2.json build/manifest.json
+    ;;
+  *)
+    cp src/manifest.json build/
+    ;;
+esac
 cp src/*.png build/

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -1,0 +1,24 @@
+{
+  "name": "ChatGPT for Firefox",
+  "description": "Display ChatGPT response in Google Search results",
+  "version": "1.0.0",
+  "manifest_version": 2,
+  "icons": {
+    "16": "logo.png",
+    "32": "logo.png",
+    "48": "logo.png",
+    "128": "logo.png"
+  },
+  "permissions": ["webRequest", "https://*.openai.com/"],
+  "background": {
+    "scripts": ["background/index.js"]
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*/search*"],
+      "include_globs": ["*.google.*/*"],
+      "js": ["content-script/index.js"],
+      "css": ["styles.css"]
+    }
+  ]
+}


### PR DESCRIPTION
By downgrading the manifest version to version 2 we could use this extension normally in the Firefox without modifying its code. 

Test on Firefox Developer Edition 108.0b5 (64-bit).

