### PR TITLE
Only Enable ChatGPT when query ends with question mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ChatGPT for Google
 
-A browser extension to display ChatGPT response alongside Google Search results, supports Chrome/Edge/Firefox
+A browser extension to display ChatGPT response alongside Google Search results, supports Chrome/Edge/Firefox.
+To better protect your privacy, and reduce the excessive usage of ChatGPT quota, ChatGPT is only enabled when the query ends with question mark (ASCII, Chinese/Japanese, or Arabic style).
 
 [<img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=369975&theme=light" />](https://www.producthunt.com/posts/chatgpt-for-google?utm_source=badge-featured)
 

--- a/src/content-script/index.mjs
+++ b/src/content-script/index.mjs
@@ -32,8 +32,17 @@ async function run(question) {
   port.postMessage({ question });
 }
 
+function endsWithQuestionMark(question) {
+  return (
+    question.endsWith("?") ||  // ASCII
+    question.endsWith("？") || // Chinese/Japanese
+    question.endsWith("؟") || // Arabic
+    question.endsWith("⸮") // Arabic
+  ); 
+}
+
 const searchInput = document.getElementsByName("q")[0];
-if (searchInput && searchInput.value) {
+if (searchInput && searchInput.value && endsWithQuestionMark(searchInput.value.trim())) {
   // only run on first page
   const startParam = new URL(location.href).searchParams.get("start") || "0";
   if (startParam === "0") {


### PR DESCRIPTION
## type
enhancement

## description

Per request by #43 and #28 , and we do see ChatGPT is occasionally and increasingly out of quota, 
<img width="390" alt="image" src="https://user-images.githubusercontent.com/7776499/206028012-08679582-cd06-4ebf-89cb-0ea33c27b563.png">, 
as well as considering many users don't wanna send everything to ChatGPT,
this PR is to enable ChatGPT only when query ends with question mark. Currently it supports question marks of ASCII (English, and many languages that use this style), Chinese/Japanese, and Arabic style.

## how
Checks if trimmed query ends with specific question marks.

## test


Below is the manual test result to show it does support such question marks, and don't include ChatGPT result when the question mark is absent.

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/7776499/206027781-34c0e798-6e6b-4349-b536-967ed3fbec82.png">

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/7776499/206028573-6ba11a9a-ec71-456e-88da-80a066a992ec.png">

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/7776499/206027653-57e7f4a2-f80d-4d08-863a-c7fba431f80c.png">

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/7776499/206028728-e2aff146-59fe-47bc-89e4-61cc031ee886.png">
