### PR TITLE
Render ChatGPT response in RTL correctly

### DIFF
--- a/src/content-script/index.mjs
+++ b/src/content-script/index.mjs
@@ -20,7 +20,7 @@ async function run(question) {
   port.onMessage.addListener(function (msg) {
     if (msg.answer) {
       container.innerHTML =
-        '<p class="prefix">ChatGPT:</p><div id="answer" class="markdown-body"></div>';
+        '<p class="prefix">ChatGPT:</p><div id="answer" class="markdown-body" dir="auto"></div>';
       container.querySelector("#answer").innerHTML = markdown.render(msg.answer);
     } else if (msg.error === "UNAUTHORIZED") {
       container.innerHTML =


### PR DESCRIPTION
## type
enhancement

## description
Per request by #32, this PR adds support for rendering ChatGPT response in RTL languages correctly.

## how
add `dir="auto"` to the `<div>` of ChatGPT response. Modern browsers support it well https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir

## test
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/7776499/206033812-dc11345f-ed06-46e2-8a1f-bb35f3c66988.png">
