### PR TITLE
Update github-markdown.css

### DIFF
--- a/src/github-markdown.css
+++ b/src/github-markdown.css
@@ -31,7 +31,7 @@
     --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
     --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
     --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-    --color-fg-default: #c9d1d9;
+    --color-fg-default: #202124;
     --color-fg-muted: #8b949e;
     --color-fg-subtle: #484f58;
     --color-canvas-default: #0d1117;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/56023297/206442234-52b23ece-f300-4beb-8e2b-30823c50d7c3.png)

As seen in this screenshot, the color of the background for the text is slightly darker than chrome and googles default color. I just went in and adjusted the styling so that it is consistent in the new mode.
