### PR TITLE
add copy to clipboard for entire gpt answer

### DIFF
--- a/src/content-script/ChatGPTFeedback.tsx
+++ b/src/content-script/ChatGPTFeedback.tsx
@@ -48,11 +48,7 @@ function ChatGPTFeedback(props: Props) {
   const clickCopyToClipboard = useCallback(async () => {
     setAction('copyToClipboard')
     setCopyToClipboard(true)
-    if ('clipboard' in navigator) {
-      await navigator.clipboard.writeText(props.answerText)
-    } else {
-      return document.execCommand('copy', true, props.answerText)
-    }
+    await navigator.clipboard.writeText(props.answerText)
   }, [props])
 
   useEffect(() => {

--- a/src/content-script/ChatGPTFeedback.tsx
+++ b/src/content-script/ChatGPTFeedback.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 function ChatGPTFeedback(props: Props) {
   const [copyToClipboard, setCopyToClipboard] = useState(false)
-  const [action, setAction] = useState<'thumbsUp' | 'thumbsDown' | 'copyToClipboard' | null>(null)
+  const [action, setAction] = useState<'thumbsUp' | 'thumbsDown' | null>(null)
 
   const clickThumbsUp = useCallback(async () => {
     if (action) {
@@ -46,7 +46,6 @@ function ChatGPTFeedback(props: Props) {
   }, [props, action])
 
   const clickCopyToClipboard = useCallback(async () => {
-    setAction('copyToClipboard')
     setCopyToClipboard(true)
     await navigator.clipboard.writeText(props.answerText)
   }, [props])

--- a/src/content-script/ChatGPTQuery.tsx
+++ b/src/content-script/ChatGPTQuery.tsx
@@ -68,7 +68,11 @@ function ChatGPTQuery(props: Props) {
           <span className="cursor-pointer leading-[0]" onClick={openOptionsPage}>
             <GearIcon size={14} />
           </span>
-          <ChatGPTFeedback messageId={answer.messageId} conversationId={answer.conversationId} />
+          <ChatGPTFeedback
+            messageId={answer.messageId}
+            conversationId={answer.conversationId}
+            answerText={answer.text}
+          />
         </div>
         <ReactMarkdown rehypePlugins={[[rehypeHighlight, { detect: true }]]}>
           {answer.text}


### PR DESCRIPTION
Added a copy to clipboard icon next to the feedback.

Normally I would need to rename the component + styles to be more suitable with "X_Action" than "X_Feedback" terminology but I didn't want to make this PR look like a refactor

let me know how this looks

![copy-to-clipboard2](https://user-images.githubusercontent.com/8100358/209715430-b61809e5-4560-4919-9c7b-ac3c575c07ef.gif)
