### PR TITLE
Add different language answers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,9 +19,20 @@ export enum Theme {
   Dark = 'dark',
 }
 
+export enum Language {
+  Auto = 'auto',
+  English = 'english',
+  Chinese = 'chinese',
+  Frech = 'frech',
+  Japanese = 'japanese',
+  Korean = 'korean',
+  Spanish = 'spanish',
+}
+
 const userConfigWithDefaultValue = {
   triggerMode: TriggerMode.Always,
   theme: Theme.Auto,
+  language: Language.Auto,
 }
 
 export type UserConfig = typeof userConfigWithDefaultValue

--- a/src/content-script/index.tsx
+++ b/src/content-script/index.tsx
@@ -1,6 +1,6 @@
 import { render } from 'preact'
 import '../base.css'
-import { getUserConfig, Theme } from '../config'
+import { getUserConfig, Language, Theme } from '../config'
 import { detectSystemColorScheme } from '../utils'
 import ChatGPTCard from './ChatGPTCard'
 import { config, SearchEngine } from './search-engine-configs'
@@ -45,11 +45,16 @@ const siteRegex = new RegExp(Object.keys(config).join('|'))
 const siteName = location.hostname.match(siteRegex)![0]
 const siteConfig = config[siteName]
 
-function run() {
+async function run() {
   const searchInput = getPossibleElementByQuerySelector<HTMLInputElement>(siteConfig.inputQuery)
   if (searchInput && searchInput.value) {
     console.debug('Mount ChatGPT on', siteName)
-    mount(searchInput.value, siteConfig)
+    const userConfig = await getUserConfig()
+    const searchValueWithLanguageOption =
+      userConfig.language === Language.Auto
+        ? searchInput.value
+        : `${searchInput.value}(in ${userConfig.language})`
+    mount(searchValueWithLanguageOption, siteConfig)
   }
 }
 

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,15 +1,26 @@
-import { CssBaseline, GeistProvider, Radio, Text } from '@geist-ui/core'
+import { CssBaseline, GeistProvider, Radio, Select, Text } from '@geist-ui/core'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import '../base.css'
-import { getUserConfig, Theme, TriggerMode, TRIGGER_MODE_TEXT, updateUserConfig } from '../config'
+import {
+  getUserConfig,
+  Language,
+  Theme,
+  TriggerMode,
+  TRIGGER_MODE_TEXT,
+  updateUserConfig,
+} from '../config'
 import logo from '../logo.png'
 import { detectSystemColorScheme } from '../utils'
 
 function OptionsPage(props: { theme: Theme; onThemeChange: (theme: Theme) => void }) {
   const [triggerMode, setTriggerMode] = useState<TriggerMode>(TriggerMode.Always)
+  const [language, setLanguage] = useState<Language>(Language.Auto)
 
   useEffect(() => {
-    getUserConfig().then((config) => setTriggerMode(config.triggerMode))
+    getUserConfig().then((config) => {
+      setTriggerMode(config.triggerMode)
+      setLanguage(config.language)
+    })
   }, [])
 
   const onTriggerModeChange = useCallback((mode: TriggerMode) => {
@@ -24,6 +35,10 @@ function OptionsPage(props: { theme: Theme; onThemeChange: (theme: Theme) => voi
     },
     [props],
   )
+
+  const onLanguageChange = useCallback((language: Language) => {
+    updateUserConfig({ language })
+  }, [])
 
   return (
     <div className="container mx-auto">
@@ -81,6 +96,21 @@ function OptionsPage(props: { theme: Theme; onThemeChange: (theme: Theme) => voi
             )
           })}
         </Radio.Group>
+        <Text h3 className="mt-10">
+          Language
+        </Text>
+        <Select
+          dropdownStyle={{ height: '180px' }}
+          value={language}
+          placeholder="Choose one"
+          onChange={(val) => onLanguageChange(val as Language)}
+        >
+          {Object.entries(Language).map(([k, v]) => (
+            <Select.Option key={k} value={v}>
+              {v}
+            </Select.Option>
+          ))}
+        </Select>
       </main>
     </div>
   )


### PR DESCRIPTION
Related issue: https://github.com/wong2/chat-gpt-google-extension/issues/158

**main changes blow:**
1. add an language options in Option page (default is "auto", the same as now)
<img width="656" alt="image" src="https://user-images.githubusercontent.com/28584664/211131850-ca504636-e9f3-4bb9-9471-d74f98b17364.png">
2. if person who select another language, the search result will show what he config.
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/28584664/211131936-cc9eac3d-df81-4f2a-b4e1-148ac517af2e.png">
